### PR TITLE
Adds three more examples to 42_threads_std

### DIFF
--- a/42_threads_std/CMakeLists.txt
+++ b/42_threads_std/CMakeLists.txt
@@ -1,12 +1,33 @@
 cmake_minimum_required (VERSION 2.6)
 project (threads_tests)
 
-#to activate c++11 and pthreads
-SET(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} "-std=c++11 -pthread")
+add_definitions(-std=c++11)
+find_package(Threads)
 
-#find threads lib
-# find_package (Threads)
+add_executable(threads_1
+	threads_1.cpp
+)
+target_link_libraries(threads_1
+	${CMAKE_THREAD_LIBS_INIT}
+)
 
-# build tests
-ADD_EXECUTABLE(threads_1 threads_1.cpp)
-# TARGET_LINK_LIBRARIES(threads_1 ${CMAKE_THREAD_LIBS_INIT})
+add_executable(atomic_sum
+	atomic_sum.cpp
+)
+target_link_libraries(atomic_sum
+	${CMAKE_THREAD_LIBS_INIT}
+)
+
+add_executable(async_sum
+	async_sum.cpp
+)
+target_link_libraries(async_sum
+	${CMAKE_THREAD_LIBS_INIT}
+)
+
+add_executable(icp_example
+	icp_example.cpp
+)
+target_link_libraries(icp_example
+	${CMAKE_THREAD_LIBS_INIT}
+)

--- a/42_threads_std/CMakeLists.txt
+++ b/42_threads_std/CMakeLists.txt
@@ -31,3 +31,10 @@ add_executable(icp_example
 target_link_libraries(icp_example
 	${CMAKE_THREAD_LIBS_INIT}
 )
+
+add_executable(icp_example_class
+	icp_example_class.cpp
+)
+target_link_libraries(icp_example_class
+	${CMAKE_THREAD_LIBS_INIT}
+)

--- a/42_threads_std/async_sum.cpp
+++ b/42_threads_std/async_sum.cpp
@@ -1,0 +1,41 @@
+#include <iostream>
+#include <thread>
+#include <vector>
+#include <atomic>
+#include <future>
+#include <chrono>
+
+// do costly operation in async (promise/future)
+uint64_t square(uint64_t x)
+{
+	return x*x;
+}
+
+int main()
+{
+	auto t0 = std::chrono::high_resolution_clock::now();
+
+	uint64_t value = 10000;
+	std::vector< std::future<uint64_t> > tasks(value);
+	for(int i = 0; i < value; i++)
+	{
+		tasks.at(i) = std::async(std::launch::async, &square, i+1);
+	}
+
+	// sum all the futures
+	// it'll wait for the promises, so wait for everyone to finish
+	// PLUS: no need for global shared variable
+	uint64_t result = 0;
+	for(auto& t : tasks)
+	{
+		result += t.get();
+	}
+
+	auto t1 = std::chrono::high_resolution_clock::now();
+	auto dt = (t1-t0).count();
+
+	std::cout << "Finished with accumulator = " << result << std::endl;
+	std::cout << "Total time (nanoseconds) = " << dt << std::endl;
+
+	return 0;
+}

--- a/42_threads_std/atomic_sum.cpp
+++ b/42_threads_std/atomic_sum.cpp
@@ -1,0 +1,39 @@
+#include <iostream>
+#include <thread>
+#include <vector>
+#include <atomic>
+#include <future>
+#include <chrono>
+
+// just a cleaner impmlementation of the mutex
+std::atomic<uint64_t>  accum(0);
+void square(uint64_t x)
+{
+	accum += x*x;
+}
+
+int main()
+{
+	auto t0 = std::chrono::high_resolution_clock::now();
+
+	uint64_t value = 10000;
+	std::vector< std::thread > tasks(value);
+	for(uint64_t i = 0; i < value; i++)
+	{
+		tasks.at(i) = std::thread(&square, i+1);
+	}
+
+	// wait for everyone to finish, with atomic
+	for(auto& t : tasks)
+	{
+		t.join();
+	}
+
+	auto t1 = std::chrono::high_resolution_clock::now();
+	auto dt = (t1-t0).count();
+
+	std::cout << "Finished with accumulator = " << accum << std::endl;
+	std::cout << "Total time (nanoseconds) = " << dt << std::endl;
+
+	return 0;
+}

--- a/42_threads_std/icp_example.cpp
+++ b/42_threads_std/icp_example.cpp
@@ -1,0 +1,53 @@
+#include <iostream>
+#include <thread>
+#include <vector>
+#include <atomic>
+#include <future>
+#include <chrono>
+
+// do costly operation in async (promise/future)
+// for instance an icp procedure
+uint64_t icp_procedure(uint64_t x)
+{
+	for(int i = 0; i < 10; i++)
+	{
+		uint64_t a = x*x;
+		std::cout << "ICP " << x << ", iteration " << i << "; x*x = " << a << std::endl;
+	}
+	return x*x;
+}
+
+int main()
+{
+	auto t0 = std::chrono::high_resolution_clock::now();
+
+	uint64_t value = 10;
+	std::vector< std::future<uint64_t> > icp_tasks(value);
+	for(int i = 0; i < value; i++)
+	{
+		icp_tasks.at(i) = std::async(std::launch::async, &icp_procedure, i+1);
+	}
+
+	// sum all the futures
+	// it'll wait for the promises, so wait for everyone to finish
+	// PLUS: no need for global shared variable
+	std::vector<uint64_t> icp_results;
+	for(auto& t : icp_tasks)
+	{
+		icp_results.push_back( t.get() );
+	}
+
+	auto t1 = std::chrono::high_resolution_clock::now();
+	auto dt = std::chrono::duration_cast<std::chrono::nanoseconds>(t1-t0);
+
+	std::cout << std::endl << "----------------------------------------"<< std::endl;
+	std::cout << "Total time for all ICPs(nanoseconds) = " << dt.count() << std::endl;
+	int i = 0;
+	for(auto r : icp_results)
+	{
+		std::cout << "ICP " << i+1 << " RESULT = " << r << std::endl;
+		i++;
+	}
+
+	return 0;
+}

--- a/42_threads_std/icp_example_class.cpp
+++ b/42_threads_std/icp_example_class.cpp
@@ -1,0 +1,80 @@
+#include <iostream>
+#include <thread>
+#include <vector>
+#include <atomic>
+#include <future>
+#include <chrono>
+
+
+class ICPer
+{
+public:
+	ICPer(){}
+	~ICPer(){}
+
+	void setValue(uint64_t __v)
+	{
+		value__ = __v;
+		icp_tasks__.resize( value__ );
+	}
+
+	void compute()
+	{
+		for(uint64_t i = 0; i < value__; i++)
+		{
+			icp_tasks__.at(i) = std::async(std::launch::async, &ICPer::icp_procedure, this, i+1);
+		}
+		
+		for(auto& t : icp_tasks__)
+		{
+			icp_results__.push_back( t.get() );
+		}
+	}
+
+	void printResults()
+	{
+		int i = 0;
+		for(auto r : icp_results__)
+		{
+			std::cout << "ICP " << i+1 << " RESULT = " << r << std::endl;
+			i++;
+		}
+	}
+
+protected:
+	uint64_t value__;
+	// do costly operation in async (promise/future)
+	// for instance an icp procedure
+	uint64_t icp_procedure(uint64_t x)
+	{
+		for(int i = 0; i < 10; i++)
+		{
+			uint64_t a = x*x;
+			std::cout << "ICP " << x << ", iteration " << i << "; x*x = " << a << std::endl;
+		}
+		return x*x;
+	}
+	std::vector< std::future<uint64_t> > icp_tasks__;
+	std::vector<uint64_t> icp_results__;
+};
+
+
+
+int main()
+{
+	auto t0 = std::chrono::high_resolution_clock::now();
+
+	uint64_t value = 10;
+	ICPer icp;
+	icp.setValue( value );
+	icp.compute();
+
+	auto t1 = std::chrono::high_resolution_clock::now();
+	auto dt = std::chrono::duration_cast<std::chrono::nanoseconds>(t1-t0);
+
+	std::cout << std::endl << "----------------------------------------"<< std::endl;
+	std::cout << "Total time for all ICPs(nanoseconds) = " << dt.count() << std::endl;
+	icp.printResults();
+
+	return 0;
+}


### PR DESCRIPTION
1. std::thread + std::atomic --> avoids the use of mutex, cleaner code,
but technically does the same thing

2. std::async + std::launch::async --> async launch policy is the same as
threads, but the result can be any type, asked at any time with get

3. An example of how an ICP procedure can be parallelize using option 2 above